### PR TITLE
Fix DNS, fix kubelet communication

### DIFF
--- a/tasks/k8s-base.yml
+++ b/tasks/k8s-base.yml
@@ -7,6 +7,21 @@
   become: true
   with_items:
     - socat
+    - ntp
+
+# https://github.com/kubernetes/kubernetes/issues/21613#issuecomment-343190401
+- name: enable required kernel modules on boot
+  lineinfile:
+    line: "br_netfilter"
+    path: /etc/modprobe.d/kubernetes.conf
+    create: true
+  become: true
+
+- name: enable required kernel modules
+  modprobe:
+    name: br_netfilter
+    state: present
+  become: true
 
 - name: get the current CNI plugins version
   command: cat /opt/cni/cni-plugins-version

--- a/tasks/pki.yml
+++ b/tasks/pki.yml
@@ -88,12 +88,22 @@
     - "{{ client_cert_stats.results }}"
     - "{{ client_key_stats.results }}"
 
-- name: generate client certificate
-  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
+- name: generate client certificate (default)
+  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }},{{ hostvars[item.0.item]['ansible_default_ipv4']['address'] }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
   run_once: true
   when: >
-    item.0.stat.exists == False
-    or item.1.stat.exists == False
+    (system_interface == 'default') and
+    (item.0.stat.exists == False or item.1.stat.exists == False)
+  with_together:
+    - "{{ client_cert_stats.results }}"
+    - "{{ client_key_stats.results }}"
+
+- name: generate client certificate
+  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }},{{ hostvars[item.0.item]['ansible_' + system_interface]['ipv4']['address'] }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
+  run_once: true
+  when: >
+    (system_interface != 'default') and
+    (item.0.stat.exists == False or item.1.stat.exists == False)
   with_together:
     - "{{ client_cert_stats.results }}"
     - "{{ client_key_stats.results }}"

--- a/templates/kubelet.service.j2
+++ b/templates/kubelet.service.j2
@@ -1,3 +1,9 @@
+#jinja2:lstrip_blocks: True
+{% if system_interface == "default" %}
+  {% set bind_ip = hostvars[inventory_hostname]['ansible_default_ipv4']['address'] %}
+{% else %}
+  {% set bind_ip = hostvars[inventory_hostname]['ansible_' + system_interface]['ipv4']['address'] %}
+{% endif %}
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/kubernetes/kubernetes
@@ -30,6 +36,7 @@ ExecStart=/usr/local/bin/kubelet \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% \
   --feature-gates=ExperimentalCriticalPodAnnotation=true \
+  --node-ip={{ bind_ip }} \
   --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= \
   --v=2
 Restart=on-failure


### PR DESCRIPTION
This PR fixes some slight issues:

* When a pod on the same node as kubedns attempted to make a DNS query in cluster, it would fail. The br_netfilter module was enabled to resolve this: https://github.com/kubernetes/kubernetes/issues/21613#issuecomment-343190401
* The kubelet has been modified to use the IP of the interface provided by the system_interface variable