### PR TITLE
Make consul template use version variable

### DIFF
--- a/templates/consul-worker.manifest.j2
+++ b/templates/consul-worker.manifest.j2
@@ -16,7 +16,7 @@ metadata:
 spec:
   containers:
   - name: consul
-    image: consul:1.1.0
+    image: consul:{{ consul_version }}
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
This PR makes the consul template honor the consul_version variable instead of hardcoding it to 1.1.0.